### PR TITLE
CORRECT pull request for eio 0.4.3 support

### DIFF
--- a/lib/engine.oil.js
+++ b/lib/engine.oil.js
@@ -13,8 +13,8 @@ Object.keys(engine).forEach(function(k) {
 
 exports.Socket = require('./socket');
 exports.Server = require('./server');
-engine.Server = exports.Server;
-engine.Socket = exports.Socket;
+engine.__proto__.Server = exports.Server;
+engine.__proto__.Socket = exports.Socket;
 
 /**
  * Captures upgrade requests for a http.Server.

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,7 @@ var BaseServer = require('../').BaseServer
   , ServerOil = require('./server.oil')
   , inherits = require('util').inherits
   , debug = require('debug')('oil')
-  , base64id = require('engine.io/node_modules/base64id/lib/base64id');
+  , base64id = require('engine.io/node_modules/base64id');
 
 function Server(opts) {
   this.oil = new ServerOil({server: this});

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@ var BaseServer = require('../').BaseServer
   , ServerOil = require('./server.oil')
   , inherits = require('util').inherits
   , debug = require('debug')('oil')
+  , base64id = require('engine.io/node_modules/base64id/lib/base64id');
 
 function Server(opts) {
   this.oil = new ServerOil({server: this});
@@ -21,7 +22,7 @@ module.exports = Server;
  */
 
 Server.prototype.handshake = function (transport, req) {
-  var id = this.id();
+  var id = base64id.generateId();
 
   debug('handshaking client "%d"', id);
 


### PR DESCRIPTION
I was able to get the chat working with the changes I did, the new engine.io added these lines: 

``` javascript
module.exports = function() {
  return exports.attach.apply(this, arguments);
};

module.exports.__proto__ = exports;
```

which will not allow to overwrite the exposed modules like engine.Socket & engine.Server, so I changed the code for it to work in engine.oil.js by adding these lines:

``` javascript
engine.__proto__.Server = exports.Server;
engine.__proto__.Socket = exports.Socket;
```

This took care of that but the test is still not passing, I think its because the first request from the client side is failing, then it reconnects and all work, but of course this will make the test fail. I think it's something on the client end that might need to change, I will come back to it later. 

Can you please check my changes and also see if you have any thoughts on the client error and failing tests.

Best,

JB
