### PR TITLE
Fix persistent ack listener

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -114,7 +114,7 @@ Client.prototype.send = function(ev, args) {
   };
   if (cb) {
     envelope.ack = idgen();
-    this.on(envelope.ack, cb);
+    this.once(envelope.ack, cb);
   }
   this.socket.send(JSON.stringify(hydration.dehydrate(envelope)));
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "mocha": "*",
     "optimist": "~0.3.4",
-    "zombie": "2.0.0-alpha19",
+    "zombie": "2.0.0-alpha29",
     "component": "~0.16.4",
     "idgen": "~1.3.0"
   },

--- a/public/engine.io.js
+++ b/public/engine.io.js
@@ -3385,7 +3385,7 @@ Client.prototype.send = function(ev, args) {
   };
   if (cb) {
     envelope.ack = idgen();
-    this.on(envelope.ack, cb);
+    this.once(envelope.ack, cb);
   }
   this.socket.send(JSON.stringify(hydration.dehydrate(envelope)));
 };

--- a/test/basic.js
+++ b/test/basic.js
@@ -26,6 +26,9 @@ describe('chat test', function() {
       done();
     });
   });
+  after(function() {
+    server.kill();
+  });
 
   it('browser1 logs in', function(done) {
     browser1


### PR DESCRIPTION
All those listeners never getting cleaned up is chewing up a lot of memory because sometimes they have bound context that doesn't get released. In the context of certain client-side apps (e.g., those using Backbone), that context can include Models and Collections, when then don't get garbage collected. And sometimes those Models and Collections have pointers to other objects, when subsequently can't get garbage collected.

Also, the older version of Zombie wasn't working on my machine (OS X Mavericks), so I bumped it to the most recent. Tests still pass. And I decided to cleanup the test server after the tests run, too. 
